### PR TITLE
main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2.1.3
-        with:
-          go-version: 1.16
-      - run: sudo apt install gcc-mingw-w64
       - uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: "nextzlog/zylo"
@@ -19,11 +15,8 @@ jobs:
           file: "zbuild-linux"
           token: ${{secrets.GITHUB_TOKEN}}
       - run: sudo chmod a+x zbuild-linux
+      - run: ./zbuild-linux setup
       - run: ./zbuild-linux compile
-      - uses: crazy-max/ghaction-upx@v1
-        with:
-          files: soumuAPI.dll
-          args: --lzma -fq
       - uses: svenstaro/upload-release-action@v2
         with:
           tag: nightly


### PR DESCRIPTION
最新のzbuildでは、aptやbrewやchocoが使える場合、`setup`コマンドを呼び出すだけで開発環境の構築ができる。また、`compile`コマンドにUPXを利用したDLLの圧縮機能が組み込まれたので、UPXを外部から呼び出す必要がなくなった。